### PR TITLE
feat(firefox): add firefox build script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,5 +48,10 @@
   },
 
   "permissions": ["storage", "background"],
-  "host_permissions": ["http://*/*", "https://*/*"]
+  "host_permissions": ["http://*/*", "https://*/*"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "extension@briefkastenhq.com"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/ndom91/briefkasten-extension#readme",
   "scripts": {
     "build": "rollup -c",
+    "build-ff": "rollup -c --firefox",
     "dev": "rollup -c -w"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,24 +1,36 @@
-import resolve from "@rollup/plugin-node-resolve"
-import commonjs from "@rollup/plugin-commonjs"
-import svelte from "rollup-plugin-svelte"
-import zip from "rollup-plugin-zip"
-import postcss from "rollup-plugin-postcss"
-import { terser } from "rollup-plugin-terser"
-import { chromeExtension, simpleReloader } from "rollup-plugin-chrome-extension"
-import { emptyDir } from "rollup-plugin-empty-dir"
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import svelte from 'rollup-plugin-svelte'
+import zip from 'rollup-plugin-zip'
+import postcss from 'rollup-plugin-postcss'
+import { terser } from 'rollup-plugin-terser'
+import { chromeExtension, simpleReloader } from 'rollup-plugin-chrome-extension'
+import { emptyDir } from 'rollup-plugin-empty-dir'
 
 const production = !process.env.ROLLUP_WATCH
+const firefox = process.argv.includes('--firefox')
+
+function firefoxManifest() {
+  return {
+    name: 'firefox-manifest',
+    generateBundle(options, bundle) {
+      const current = JSON.parse(bundle['manifest.json'].source)
+      current.background = { scripts: [current.background.service_worker] }
+      bundle['manifest.json'].source = JSON.stringify(current, null, 2)
+    },
+  }
+}
 
 export default {
-  input: "manifest.json",
+  input: 'manifest.json',
   // output: {
   //   dir: "dist",
   //   format: "esm",
   // },
   output: {
-    format: "esm",
-    name: "briefkasten",
-    dir: "dist",
+    format: 'esm',
+    name: 'briefkasten',
+    dir: 'dist',
     // file: 'build/bundle.js'
   },
   plugins: [
@@ -35,7 +47,7 @@ export default {
     // the plugins below are optional
     resolve({
       browser: true, // @NOTE: OG
-      dedupe: ["svelte"],
+      dedupe: ['svelte'],
     }),
     // https://github.com/rollup/plugins/tree/master/packages/commonjs
     commonjs(),
@@ -43,7 +55,9 @@ export default {
     emptyDir(),
     // If we're building for production, minify
     production && terser(),
+    // Make adjustments for firefox
+    firefox && firefoxManifest(),
     // Outputs a zip file in ./releases
-    production && zip({ dir: "releases" }),
+    production && zip({ dir: 'releases' }),
   ],
 }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds a Firefox-specific build script. This is needed due to Firefox not fully being compatible with the new manifest v3 service worker change.

This also adds a `browser_specific_settings` to the `manifest.json` because the AMO (Firefox's addon store) now requires a browser-specific id in order to submit an addon.

### Linked Issues

Fixes #2 

### Additional context

The `id` used for Firefox can be changed to anything, but I followed the format recommended by Mozilla.
